### PR TITLE
second commit : build and UI fixes

### DIFF
--- a/Source/Microsoft.Teams.Apps.CannedResponses/Microsoft.Teams.Apps.CannedResponses.csproj
+++ b/Source/Microsoft.Teams.Apps.CannedResponses/Microsoft.Teams.Apps.CannedResponses.csproj
@@ -54,6 +54,9 @@
     <AdditionalFiles Include="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), .gitignore))\Build\stylecop.json" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="wwwroot\Artifacts\appLogo.png" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Update="Resources\Strings.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
@@ -66,9 +69,6 @@
       <LastGenOutput>Strings.Designer.cs</LastGenOutput>
       <CustomToolNamespace>Microsoft.Teams.Apps.CannedResponses</CustomToolNamespace>
     </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="wwwroot\" />
   </ItemGroup>
   <Target Name="DebugEnsureNodeEnv" BeforeTargets="Build" Condition=" '$(Configuration)' == 'Debug' And !Exists('$(SpaRoot)node_modules') ">
     <!-- Ensure Node.js is installed -->

--- a/Source/Microsoft.Teams.Apps.CannedResponses/Microsoft.Teams.Apps.CannedResponses.csproj
+++ b/Source/Microsoft.Teams.Apps.CannedResponses/Microsoft.Teams.Apps.CannedResponses.csproj
@@ -64,6 +64,7 @@
     <EmbeddedResource Update="Resources\Strings.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Strings.Designer.cs</LastGenOutput>
+      <CustomToolNamespace>Microsoft.Teams.Apps.CannedResponses</CustomToolNamespace>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>

--- a/Source/Microsoft.Teams.Apps.CannedResponses/Resources/Strings.Designer.cs
+++ b/Source/Microsoft.Teams.Apps.CannedResponses/Resources/Strings.Designer.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Microsoft.Teams.Apps.CannedResponses.Resources {
+namespace Microsoft.Teams.Apps.CannedResponses {
     using System;
     
     


### PR DESCRIPTION
[Fix] : Strings.resx is taking the default namespace which was not accessible by other files in the project. Modified the resource file properties Custom Tool Namespace to user Microsoft.Teams.Apps.CannedResponses. 

[Fix] : included app icon as a part of build which is shown in welcome card. 